### PR TITLE
Issue #2 - Do not export database server configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solr Export Config
 
-A drupal module, that will export search_api_solr solr server configuration after each `drush config:export`
+A drupal module, that will export enabled search_api_solr solr server configuration after each `drush config:export`
 
 ### Installation
 

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -3,5 +3,6 @@ services:
     class: Drupal\solr_export_config\Commands\SolrExportConfigCommands
     arguments:
       - '@config.factory'
+      - '@entity_type.manager'
     tags:
       - { name: drush.command }


### PR DESCRIPTION
For #2.  The `sapi-sl` command doesn't output server types to select on, so using the Drupal API to grab this info instead.