### PR TITLE
Issue #7 - Adding config schema definition.

### DIFF
--- a/config/schema/solr_export_config.schema.yml
+++ b/config/schema/solr_export_config.schema.yml
@@ -1,0 +1,11 @@
+solr_export_config.settings:
+  type: config_object
+  label: 'Solr Export Config settings'
+  mapping:
+    solr_conf_dir:
+      type: string
+      label: 'Solr configuration directory'
+      constraints:
+        Regex:
+          pattern: '/^\/.*/'
+          message: 'The path %value has to start with a slash.'

--- a/src/Commands/SolrExportConfigCommands.php
+++ b/src/Commands/SolrExportConfigCommands.php
@@ -32,6 +32,11 @@ class SolrExportConfigCommands extends DrushCommands {
 
   /**
    * React to the config:export, export solr configs post config:export.
+   *
+   * @param mixed $result
+   *   The result of the command.
+   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+   *   The command data.
    */
   #[CLI\Hook(type: HookManager::POST_COMMAND_HOOK, target: 'config:export')]
   public function postConfigExport($result, CommandData $commandData): void {
@@ -40,6 +45,7 @@ class SolrExportConfigCommands extends DrushCommands {
 
     // Get all the enabled search API solr servers.
     $sapi_storage = $this->entityTypeManager->getStorage('search_api_server');
+    /** @var \Drupal\search_api\ServerInterface[] $servers */
     $servers = $sapi_storage->loadMultiple();
 
     foreach ($servers as $server) {


### PR DESCRIPTION
This is easies to test with the config_inspector module.

## Testing Instructions
- Run the following commands
```
ddev composer require drupal/config_inspector
ddev drush pm:enable config_inspector
ddev drush config:inspect --filter-keys=solr_export_config.settings --detail --list-constraints
```
- You should see the schema validates with no errors.

```
 -------------------------------------------------------- --------- ------------- ------ --------------------------------------------------------- 
  Key                                                      Status    Validatable   Data   Validation constraints                                   
 -------------------------------------------------------- --------- ------------- ------ --------------------------------------------------------- 
  solr_export_config.settings                              Correct   100%          ✅✅   ValidKeys: '<infer>'                                     
                                                                                          LangcodeRequiredIfTranslatableValues: null               
   solr_export_config.settings:                            Correct   Validatable   ✅✅   ValidKeys: '<infer>'                                     
                                                                                          LangcodeRequiredIfTranslatableValues: null               
   solr_export_config.settings:_core                       Correct   Validatable   ✅✅   ValidKeys:                                               
                                                                                            - default_config_hash                                  
   solr_export_config.settings:_core.default_config_hash   Correct   Validatable   ✅✅   NotNull: {  }                                            
                                                                                          Regex:                                                   
                                                                                            pattern: '/^[a-zA-Z0-9\-_]+$/'                         
                                                                                          Length:                                                  
                                                                                            exactly: 43                                            
                                                                                          ↣ PrimitiveType: {  }                                    
   solr_export_config.settings:solr_conf_dir               Correct   Validatable   ✅✅   Regex:                                                   
                                                                                            pattern: '/^\/.*/'                                     
                                                                                            message: 'The path %value has to start with a slash.'  
                                                                                          ↣ PrimitiveType: {  }                                    
 -------------------------------------------------------- --------- ------------- ------ --------------------------------------------------------- 
```